### PR TITLE
Fix duplicate type export errors in i18n and advanced-features

### DIFF
--- a/b3-erp/frontend/src/components/advanced-features/ARIntegration.tsx
+++ b/b3-erp/frontend/src/components/advanced-features/ARIntegration.tsx
@@ -756,14 +756,3 @@ export function StepByStepGuide({
   );
 }
 
-export type {
-  ARMarker,
-  ARAnnotation,
-  ARStep,
-  MaintenanceGuide,
-  ARState,
-  ARProviderProps,
-  ARViewerProps,
-  MaintenanceGuideListProps,
-  StepByStepGuideProps,
-};

--- a/b3-erp/frontend/src/components/advanced-features/ChatbotAssistant.tsx
+++ b/b3-erp/frontend/src/components/advanced-features/ChatbotAssistant.tsx
@@ -775,17 +775,3 @@ export function InlineChat({ className = '' }: InlineChatProps) {
   );
 }
 
-export type {
-  MessageRole,
-  MessageStatus,
-  ChatMessage,
-  ChatAction,
-  QuickReply,
-  ChatbotConfig,
-  ChatbotState,
-  Intent,
-  ChatContext,
-  ChatbotProviderProps,
-  ChatWidgetProps,
-  InlineChatProps,
-};

--- a/b3-erp/frontend/src/components/advanced-features/VideoConferencing.tsx
+++ b/b3-erp/frontend/src/components/advanced-features/VideoConferencing.tsx
@@ -874,15 +874,3 @@ export function JoinMeetingDialog({
   );
 }
 
-export type {
-  Participant,
-  ChatMessage as VideoMessage,
-  MeetingInfo,
-  CallState,
-  VideoConferenceProviderProps,
-  VideoGridProps,
-  VideoTileProps,
-  MeetingControlsProps,
-  MeetingChatProps,
-  JoinMeetingDialogProps,
-};

--- a/b3-erp/frontend/src/components/advanced-features/VoiceCommands.tsx
+++ b/b3-erp/frontend/src/components/advanced-features/VoiceCommands.tsx
@@ -772,13 +772,3 @@ export const createNavigationCommands = (
   },
 ];
 
-export type {
-  VoiceCommand,
-  VoiceCommandMatch,
-  VoiceState,
-  SpeechOptions,
-  VoiceCommandProviderProps,
-  VoiceButtonProps,
-  VoiceSearchProps,
-  VoiceCommandHelpProps,
-};

--- a/b3-erp/frontend/src/components/advanced-features/index.ts
+++ b/b3-erp/frontend/src/components/advanced-features/index.ts
@@ -80,7 +80,6 @@ export {
 
 export type {
   Participant,
-  VideoMessage,
   MeetingInfo,
   CallState,
   VideoConferenceProviderProps,
@@ -90,3 +89,6 @@ export type {
   MeetingChatProps,
   JoinMeetingDialogProps,
 } from './VideoConferencing';
+
+// Re-export ChatMessage as VideoMessage for backwards compatibility
+export { type ChatMessage as VideoMessage } from './VideoConferencing';

--- a/b3-erp/frontend/src/components/i18n/LanguageSwitcher.tsx
+++ b/b3-erp/frontend/src/components/i18n/LanguageSwitcher.tsx
@@ -690,11 +690,3 @@ export function TranslatedText({
 // Shorthand alias
 export const T = TranslatedText;
 
-export type {
-  LanguageCode,
-  Language,
-  LanguageProviderProps,
-  LanguageSwitcherProps,
-  LanguageSelectProps,
-  TranslatedTextProps,
-};

--- a/b3-erp/frontend/src/components/i18n/LocaleFormatting.tsx
+++ b/b3-erp/frontend/src/components/i18n/LocaleFormatting.tsx
@@ -776,16 +776,3 @@ export function TimezoneSelector({
   );
 }
 
-export type {
-  LocaleCode,
-  LocaleConfig,
-  LocaleProviderProps,
-  FormattedDateProps,
-  FormattedNumberProps,
-  CurrencyDisplayProps,
-  DateRangeProps,
-  RelativeTimeProps,
-  LocaleNumberInputProps,
-  CurrencySelectorProps,
-  TimezoneSelectorProps,
-};

--- a/b3-erp/frontend/src/components/i18n/RTLSupport.tsx
+++ b/b3-erp/frontend/src/components/i18n/RTLSupport.tsx
@@ -563,14 +563,3 @@ export function RTLStyleSheet() {
   );
 }
 
-export type {
-  RTLProviderProps,
-  RTLFlexProps,
-  RTLIconProps,
-  RTLTextProps,
-  RTLBoxProps,
-  RTLPositionProps,
-  BidiTextProps,
-  LogicalPosition,
-  PhysicalPosition,
-};

--- a/b3-erp/frontend/src/components/i18n/TranslationSystem.tsx
+++ b/b3-erp/frontend/src/components/i18n/TranslationSystem.tsx
@@ -806,14 +806,3 @@ export function TranslationDebug({
   return null;
 }
 
-export type {
-  TranslationKey,
-  TranslationParams,
-  TranslationNamespace,
-  TranslationResource,
-  TranslationResources,
-  TranslationProviderProps,
-  TransProps,
-  PluralProps,
-  TranslationDebugProps,
-};


### PR DESCRIPTION
Removed duplicate export type declarations that were causing TypeScript TS2484 errors. Interfaces exported inline with 'export interface' don't need to be re-exported with 'export type {}' blocks.

Fixed files:
- i18n: LanguageSwitcher, RTLSupport, LocaleFormatting, TranslationSystem
- advanced-features: VoiceCommands, ARIntegration, ChatbotAssistant, VideoConferencing
- Fixed VideoMessage alias export in advanced-features/index.ts