### PR TITLE
docs(adr): ADR-0004 dual-backend architecture + diagram (closes #118)

### DIFF
--- a/docs/adr/0004-dual-backend-django-and-nestjs.md
+++ b/docs/adr/0004-dual-backend-django-and-nestjs.md
@@ -1,0 +1,140 @@
+# ADR-0004: Dual-backend architecture — OptiForge (Django) + b3-erp (NestJS)
+
+*Status: Proposed*
+*Date: 2026-04-24*
+*Deciders: Bosco*
+*Related: [ADR-0001](./0001-five-layer-architecture.md), [ADR-0002](./0002-modular-monolith.md), [PRD](../prds/optiforge-layered-multi-industry-architecture.md), [`docs/architecture.md`](../architecture.md)*
+
+## Context
+
+The repository hosts **two backends running concurrently**, but neither the PRD nor existing ADRs acknowledge this:
+
+| Backend | Stack | Location | Recent activity | Test coverage |
+|---|---|---|---|---|
+| **OptiForge** | Django 4.2 + DRF + Postgres 15 | `/backend/` | 21 commits in 6 months; all `feat(phase-N)` land here | 14 pytest modules across 7 categories (canary, contract, performance, dr_drill, second_pack, acero, scaffolded_mode) |
+| **b3-erp** | NestJS 10 + TypeORM + Postgres | `/b3-erp/backend/` | **165 commits in 6 months**; last touch 2026-04-23 | 8 Jest unit specs |
+
+There are also two frontends:
+
+| Frontend | Stack | Location | Size |
+|---|---|---|---|
+| **b3-erp/frontend** | Next.js 14 + TypeScript + shadcn | `/b3-erp/frontend/` | **2,389 `.tsx` files, 1,719 pages** — the real, feature-complete UI |
+| **top-level /frontend** | Next.js | `/frontend/` | 6 `.tsx` files — appears to be a scaffold |
+
+The b3-erp frontend's API clients call **both** backends:
+
+- `b3-erp/frontend/src/context/AuthContext.tsx:32` — `http://localhost:8000/api/v1` (Django)
+- `b3-erp/frontend/src/lib/api-client.ts:4` — `http://localhost:8000/api/v1` (Django)
+- `b3-erp/frontend/src/services/loan.service.ts:6` — `http://localhost:3001` (NestJS)
+- `b3-erp/frontend/src/services/bonus.service.ts:6` — `http://localhost:3001` (NestJS)
+- `b3-erp/frontend/src/app/(modules)/procurement/approvals/page.tsx:89` — `http://localhost:4000` (unknown)
+
+Documentation that currently misrepresents this reality:
+
+- [`CLAUDE.md`](../../CLAUDE.md) describes only NestJS + TypeORM and points at `b3-erp/` as the monorepo. It omits Django entirely.
+- [`README.md`](../../README.md) describes only Django + DRF + Celery. It omits the NestJS backend entirely, and its status table shows Phases 1–5 "Not started" while git log confirms Phases 2–6 have merged.
+- [`docs/architecture.md`](../architecture.md), the PRD, ADR-0001, and ADR-0002 all describe OptiForge (Django) as if it were the only backend.
+
+The dual-backend reality has not been decided — it has *accumulated*. A new developer or AI agent reading any one source of documentation will form a wrong mental model of the system.
+
+This ADR is the **first attempt to write down what is true** and propose a single coherent interpretation. It is deliberately marked `Proposed` because only the project owners can ratify the intended end state.
+
+## Decision
+
+Accept the following for v1, pending owner ratification of the intended end state:
+
+1. **OptiForge (Django, `/backend/`) is the platform backend of record.** It owns: tenancy, identity, audit, extensions, events, workflow, notifications, reporting, documents, integration, api_gateway, observability, localisation, and the layered Core/Modes/Compliance/Packs stack described in ADR-0001 and PRD. All `feat(phase-N)` work continues to land here.
+
+2. **b3-erp (NestJS, `/b3-erp/backend/`) is the domain services backend for the existing MACBIS feature set.** It owns the 29 application modules that currently power `b3-erp/frontend`: HR (statutory, bonuses, loans, skills, training), CRM, sales, procurement, inventory, logistics, finance, production, project-management, quality, approvals, notifications, workflow, accounts, after-sales-service, cms, common-masters, CPQ, core (items/categories/UOM), estimation, IT-admin, proposals, reports, support.
+
+3. **`b3-erp/frontend` (Next.js, `/b3-erp/frontend/`) is the single frontend of record** for v1. It routes to whichever backend owns the domain. The top-level `/frontend/` is a scaffold only and is NOT a live UI.
+
+4. **The routing contract** between frontend and the two backends is explicit and documented:
+   - Frontend API clients use **exactly two base URLs**, sourced from environment variables:
+     - `NEXT_PUBLIC_PLATFORM_API_URL` → OptiForge (Django), default `http://localhost:8000/api/v1`
+     - `NEXT_PUBLIC_DOMAIN_API_URL` → b3-erp (NestJS), default `http://localhost:3001`
+   - Any hardcoded URL or third port (e.g., `localhost:4000`) is a bug and gets removed.
+
+5. **Both backends share one Postgres cluster but live in separate schemas** (`optiforge.*` and `b3_erp.*`) in the same physical database for v1. This makes cross-backend reads possible via read-only views without requiring a distributed transaction coordinator. Writes remain strictly single-backend.
+
+6. **Auth is federated via OpenID Connect** (per ADR-0003, OIDC Provider: Keycloak). Both backends validate JWTs issued by Keycloak; neither issues its own session tokens in v1. (This is already the direction in ADR-0003; this ADR merely confirms it applies to both backends.)
+
+7. **The long-term direction is not committed by this ADR.** Options — consolidate onto Django, consolidate onto NestJS, split into services, or keep the current split — remain open. A follow-up ADR will decide once the v1 ship has settled.
+
+## Alternatives considered
+
+### Alternative A — Document reality and propose a coherent routing/data contract (**CHOSEN**)
+
+Write this ADR. Clarify which backend owns which domains. Fix the docs so new developers and AI tools get the right mental model. Defer the "which backend wins long-term" decision.
+
+**Trade-off.** Preserves all existing work. Unblocks onboarding and the remaining backend-improvement milestone (pagination, soft-delete, docker-compose, CI) which would otherwise have to solve the same problem twice without coordination. Does not force a premature rewrite decision.
+
+### Alternative B — Consolidate on Django immediately, archive NestJS
+
+Declare OptiForge (Django) the only backend. Port the 29 NestJS modules over. Archive `b3-erp/backend/`. Update the frontend to call only Django.
+
+**Trade-off.** Cleanest end state, but ignores reality: NestJS has 165 commits in 6 months and is *more actively maintained than Django by volume*. Porting 29 modules is a multi-month effort that would stop all feature work. **Rejected** as premature and disruptive.
+
+### Alternative C — Consolidate on NestJS, archive Django
+
+Declare b3-erp (NestJS) the only backend. Port OptiForge's platform services (tenancy RLS, import-linter seam, extension framework, compliance hooks) to NestJS.
+
+**Trade-off.** Would throw away the load-bearing architectural work of Phases 1–6 (ADR-0001 seam enforcement, extension registry, pack loader, compliance scaffolding, audit immutability). **Rejected** — the layered architecture is not easily re-expressed in TypeORM, and the effort would exceed Alternative B's.
+
+### Alternative D — Split on clean architectural lines: Django for platform+compliance, NestJS for domain
+
+Very similar to the chosen option, but formalise the split as permanent and forbid domain logic from ever going into Django (or platform from ever going into NestJS).
+
+**Trade-off.** Clean boundary, but hard to enforce without a runtime gateway. Some domains (e.g., Sales CPQ, Procurement) already have implementations in both and would need to pick one. Deferred for a future ADR.
+
+## Consequences
+
+### Easier
+
+- Documentation becomes truthful. New developers know what they're looking at.
+- Remaining backend-improvement work (#113 soft-delete, #114 pagination, #115 docker-compose, #116 CI) can be scoped consistently across **both** backends with shared semantics, not handled twice in isolation.
+- Frontend API routing becomes standard (two env vars, two base URLs).
+- AI agents reading the repo stop recommending "archive b3-erp" based on partial evidence.
+
+### Harder
+
+- Every backend-level concern (auth, pagination, audit columns, error format, observability hook) now has to be implemented twice and kept in lockstep. An ADR or shared contract is required every time.
+- Cross-backend transactions remain impossible. Any flow that spans domains in both backends must use eventual consistency (events) or be restructured to live in one backend.
+- Schema migrations run in two toolchains: Django `manage.py migrate` and TypeORM `migration:run`. Deployment order matters.
+- Two runtimes to patch, two dependency trees to audit, two sets of CVEs to track.
+
+### Obligations accepted
+
+- **Shared contracts are written down, not implicit.** Every pattern that must be consistent across backends (audit columns, soft-delete semantics, pagination defaults, error envelope, JWT claims) gets a single ADR and is implemented identically in both.
+- **No new domain in Django without an ADR justifying it.** The default home for new domain features is b3-erp/NestJS; the default home for new platform features is OptiForge/Django.
+- **The frontend has exactly two API base URLs.** Any service file introducing a third gets rejected in review.
+- **Both backends run under `optiforge-ci.yml` or a successor unified workflow.** The existing `ci.yml` (NestJS) and `optiforge-ci.yml` (Django) stay independent for v1 but both are `required` on PRs that touch their paths.
+
+### No-longer-possible (in v1)
+
+- A single source of truth for domain data across all modules. (It isn't — some data lives in Django tables, some in NestJS tables.)
+- A single ORM-level transaction spanning HR (NestJS) and audit records (Django). Use the platform event bus (`optiforge.platform.events`) for cross-backend effects.
+- Simple "delete all data for a tenant" — must be run twice, once per backend, in the correct order.
+
+### When to revisit
+
+- Cross-backend eventual consistency causes production incidents or customer-visible data staleness.
+- One backend's test coverage remains below 50% of the other for two consecutive quarters — suggests the neglected backend is actually dead.
+- A major feature naturally straddles both backends and the coordination overhead dominates the implementation time — time to pick one.
+- The v1 deployment is cut and the team has bandwidth to consolidate.
+
+## Open questions (require owner input before `Status: Accepted`)
+
+These are **not** blockers for the rest of the backend-improvement milestone — the milestone proceeds under this Proposed ADR. They ARE blockers before this ADR is marked `Accepted`:
+
+1. **Q1: Is the long-term intent to consolidate, or to keep the split?** Answer drives whether we invest in a unified API gateway in front of both backends.
+2. **Q2: Do Django and NestJS share a physical Postgres cluster (proposed §5) or separate databases?** Current code ambiguous.
+3. **Q3: Which backend owns the `tenant_id` authority?** OptiForge has `Tenant` model with status transitions; does NestJS read from it or maintain its own copy?
+4. **Q4: Is there a plan to port any NestJS module to Django (or vice versa)?** Affects whether we invest in new work on the "donor" side.
+5. **Q5: Is the top-level `/frontend/` (6 .tsx files) salvageable or should it be removed?** Its package.json scripts in root `package.json` point at `b3-erp/`, so root `npm run dev` already uses b3-erp/frontend — the top-level /frontend is probably abandonable.
+
+## References
+
+- [`CLAUDE.md`](../../CLAUDE.md) and [`README.md`](../../README.md) — currently misleading; will be rewritten under backend-improvement issue #112.
+- Backend-improvement milestone: https://github.com/boscosabujohn/ManufacturingOS/milestone/2
+- Originating review: conversational A-Z review conducted 2026-04-24.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,6 +41,8 @@ Links to PRDs, brainstorms, issues, external sources.
 |---|---|---|---|
 | 0001 | [Five-layer architecture (Platform → Core → Modes → Compliance → Industry)](./0001-five-layer-architecture.md) | Accepted | 2026-04-23 |
 | 0002 | [Modular monolith deployment (defer microservices)](./0002-modular-monolith.md) | Accepted | 2026-04-23 |
+| 0003 | [Keycloak as OIDC Provider](./0003-oidc-provider-keycloak.md) | Accepted | 2026-04-23 |
+| 0004 | [Dual-backend architecture — OptiForge (Django) + b3-erp (NestJS)](./0004-dual-backend-django-and-nestjs.md) | Proposed | 2026-04-24 |
 
 _Add new ADRs at the bottom. Do not renumber existing ones._
 

--- a/docs/architecture-dual-backend.md
+++ b/docs/architecture-dual-backend.md
@@ -1,0 +1,126 @@
+# ManufacturingOS — Dual-Backend Architecture (live system diagram)
+
+This document is the canonical picture of *how the running system fits together today*, as accepted (proposed) in [ADR-0004](./adr/0004-dual-backend-django-and-nestjs.md). It complements [`architecture.md`](./architecture.md), which describes the **OptiForge layered architecture** inside the Django backend.
+
+## High-level diagram
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│                          Browser / Next.js client                          │
+│                                                                            │
+│  /b3-erp/frontend  (Next.js 14, shadcn, 1,719 pages)                       │
+│                                                                            │
+│   ┌──────────────────────────┐      ┌──────────────────────────────────┐   │
+│   │  Platform API client     │      │  Domain API client               │   │
+│   │  NEXT_PUBLIC_PLATFORM_   │      │  NEXT_PUBLIC_DOMAIN_API_URL      │   │
+│   │  API_URL                 │      │                                  │   │
+│   └────────┬─────────────────┘      └──────────────┬───────────────────┘   │
+└────────────┼──────────────────────────────────────┼────────────────────────┘
+             │                                      │
+             │  HTTPS / JWT (Keycloak-issued)       │  HTTPS / JWT (same)
+             │                                      │
+             ▼                                      ▼
+┌──────────────────────────────┐    ┌──────────────────────────────────────┐
+│  OptiForge (Django + DRF)    │    │  b3-erp (NestJS + TypeORM)           │
+│  /backend/                   │    │  /b3-erp/backend/                    │
+│                              │    │                                      │
+│  Platform services (13):     │    │  Domain modules (29):                │
+│   · tenancy + RLS            │    │   · HR (statutory, training, loans,  │
+│   · identity                 │    │      bonuses, skills)                │
+│   · audit (immutable)        │    │   · CRM, Sales, CPQ, Procurement     │
+│   · extensions (pack loader) │    │   · Inventory, Logistics, Finance    │
+│   · events                   │    │   · Production, Project-mgmt, QMS    │
+│   · workflow                 │    │   · Approvals, Workflow, Notifs      │
+│   · notifications            │    │   · Common-masters, IT-admin         │
+│   · reporting                │    │   · Reports, Support                 │
+│   · documents                │    │                                      │
+│   · integration              │    │                                      │
+│   · api_gateway              │    │                                      │
+│   · observability            │    │                                      │
+│   · localisation             │    │                                      │
+│                              │    │                                      │
+│  Core modules (21) under the │    │                                      │
+│  five-layer architecture of  │    │                                      │
+│  ADR-0001.                   │    │                                      │
+│                              │    │                                      │
+│  Port: 8000                  │    │  Port: 3001                          │
+│  Schema: optiforge.*         │    │  Schema: b3_erp.*                    │
+└──────────────┬───────────────┘    └──────────────────┬───────────────────┘
+               │                                       │
+               │  psycopg2                             │  pg (node-postgres)
+               │                                       │
+               ▼                                       ▼
+          ┌─────────────────────────────────────────────────┐
+          │  PostgreSQL 15  (single cluster, two schemas)   │
+          │  ┌─────────────────┐  ┌────────────────────┐    │
+          │  │  optiforge.*    │  │  b3_erp.*          │    │
+          │  │  (Django owns)  │  │  (NestJS owns)     │    │
+          │  └─────────────────┘  └────────────────────┘    │
+          │                                                 │
+          │  Cross-schema reads: allowed via read-only      │
+          │  views. Cross-schema writes: forbidden.         │
+          └─────────────────────────────────────────────────┘
+
+          ┌─────────────────┐   ┌─────────────────┐   ┌─────────────────┐
+          │  Redis          │   │  RabbitMQ       │   │  Keycloak       │
+          │  (cache,        │   │  (Celery broker,│   │  (OIDC IdP,     │
+          │   Celery res.)  │   │   event bus)    │   │   ADR-0003)     │
+          └─────────────────┘   └─────────────────┘   └─────────────────┘
+```
+
+## Routing rules (frontend → backend)
+
+The b3-erp frontend decides which backend to call per domain. The mapping is explicit:
+
+| Domain path prefix | Target backend | Base URL env var |
+|---|---|---|
+| `/auth/*` (login, refresh, MFA) | Django platform | `NEXT_PUBLIC_PLATFORM_API_URL` |
+| `/tenants/*`, `/users/*`, `/roles/*` | Django platform | `NEXT_PUBLIC_PLATFORM_API_URL` |
+| `/audit/*`, `/workflows/*`, `/notifications/*` | Django platform | `NEXT_PUBLIC_PLATFORM_API_URL` |
+| `/customer-requirements/*`, `/quotations/*` (OptiForge CPQ) | Django platform | `NEXT_PUBLIC_PLATFORM_API_URL` |
+| `/hr/*`, `/crm/*`, `/sales/*`, `/inventory/*`, `/finance/*`, `/procurement/*`, `/production/*`, `/logistics/*`, `/projects/*`, `/quality/*`, `/approvals/*` | NestJS domain | `NEXT_PUBLIC_DOMAIN_API_URL` |
+| `/common-masters/*` | NestJS domain | `NEXT_PUBLIC_DOMAIN_API_URL` |
+
+**Rule:** `b3-erp/frontend/src/services/*.ts` uses exactly one of those two env vars. Any new service file using a different host gets caught in review.
+
+## Auth flow
+
+1. User logs in via Keycloak (federated via Django's `optiforge.platform.identity`).
+2. Keycloak issues a JWT containing `sub`, `tenant_id`, `roles`, and standard OIDC claims.
+3. Frontend stores the JWT (cookie, `HttpOnly`) and attaches it to both API clients.
+4. Both backends validate the JWT against Keycloak's JWKS endpoint. Neither mints its own session token.
+5. Tenant scoping:
+   - Django enforces via RLS (`TenantMiddleware` sets `current_setting('app.tenant_id')`, Postgres policies filter).
+   - NestJS enforces via `TenantGuard` on every controller, filtering by `tenantId` column on each TypeORM entity.
+
+## Data contracts that must stay identical across both backends
+
+These are the cross-cutting concerns that ADR-0004 §"Obligations accepted" pins to a single shared contract:
+
+| Concern | Pattern | Django implementation | NestJS implementation |
+|---|---|---|---|
+| Audit columns | `created_at`, `updated_at`, `created_by`, `updated_by`, `deleted_at`, `deleted_by` | `optiforge.platform.tenancy.models.AuditedTenantModel` (see issue #113) | `b3-erp/backend/src/common/entities/base.entity.ts` (see issue #113) |
+| Soft delete | `deleted_at IS NULL` default filter; `all_objects`/`withDeleted()` for explicit recovery | Custom manager on `AuditedTenantModel` | Subscriber + repo helper on `SoftDeletableAuditedEntity` |
+| Pagination | Default 50, hard max 500. Cursor pagination for insert-heavy tables, page-number elsewhere | DRF `DEFAULT_PAGINATION_CLASS` + `PAGE_SIZE` | `@Query()` DTO + interceptor + response envelope (see issue #114) |
+| Error envelope | `{ "error": { "code": str, "message": str, "details": object, "correlation_id": uuid } }` | `optiforge.platform.api_gateway` exception middleware | `b3-erp/backend/src/common/filters/global-exception.filter.ts` |
+| JWT claims consumed | `sub`, `tenant_id`, `roles[]`, `email`, `exp`, `iat` | `optiforge.platform.identity` | `b3-erp/backend/src/modules/auth` |
+
+If a new cross-cutting concern appears, it gets added here and implemented identically in both.
+
+## What lives where (fast lookup table)
+
+**Django owns:** Tenancy, Identity, Audit, Extensions, Events, Workflow, Notifications, Reporting, Documents, Integration, API Gateway, Observability, Localisation, OptiForge Core (CRM · Sales · Procurement · Inventory · WMS · Project · HR · PLM · IT-Admin · S&OP · CMMS · EHS · Production Planning · MES · Finance · QMS · Analytics · Field Service · Commissioning · Logistics · Support), OptiForge Modes (ETO, Discrete), OptiForge Packs (KitchenEquipment).
+
+**NestJS owns:** HR (statutory/training/bonuses/loans/skills), CRM, Sales (MACBIS flow), CPQ, Procurement, Inventory, Logistics, Finance, Production, Project management, Quality, Approvals, Workflow (MACBIS-specific), Notifications (MACBIS-specific), Common-masters, Accounts, After-sales-service, CMS, Estimation, IT-admin, Proposals, Reports, Support.
+
+**Overlap** (same domain in both): CRM, Sales, Procurement, Inventory, Finance, HR, Production, Logistics, Project. These are *known overlaps* — ADR-0004 §"Alternative D" flags them for a future ADR that picks one owner per domain.
+
+## Links
+
+- ADR-0001: [Five-layer architecture](./adr/0001-five-layer-architecture.md)
+- ADR-0002: [Modular monolith deployment](./adr/0002-modular-monolith.md)
+- ADR-0003: [Keycloak as OIDC Provider](./adr/0003-oidc-provider-keycloak.md)
+- ADR-0004: [Dual-backend architecture — OptiForge (Django) + b3-erp (NestJS)](./adr/0004-dual-backend-django-and-nestjs.md) ← **this page's spec**
+- [OptiForge layered architecture (Django-internal)](./architecture.md)
+- [README](../README.md) — overview and getting-started
+- [CLAUDE.md](../CLAUDE.md) — AI-assistant configuration


### PR DESCRIPTION
## Summary

- Adds **ADR-0004** documenting the dual-backend reality (Django `/backend/` + NestJS `/b3-erp/backend/`) with a proposed routing/data contract, and flags 5 open questions for owner ratification.
- Adds **`docs/architecture-dual-backend.md`** — the live-system diagram, routing rules, auth flow, and a table of cross-cutting concerns that must stay identical across both backends.
- Fixes the ADR index: adds ADR-0003 (Keycloak, already accepted but missing from the table) and ADR-0004.

Status of ADR-0004 is **Proposed**, not Accepted — I don't have authority to pin down long-term intent (consolidate, split, status-quo). The rest of the backend-improvement milestone (#112, #113, #114, #115, #116) proceeds under this Proposed ADR as shared frame.

## Why now

The A-Z review on 2026-04-24 surfaced a mismatch: CLAUDE.md describes NestJS only, README.md describes Django only, and neither mentions both or that `b3-erp/frontend` is the feature-complete UI calling both. Any new developer forms a wrong mental model. This ADR is the first written version of what is actually true.

## Open questions in the ADR (need owner input before Accepted)

1. Long-term intent — consolidate or keep the split?
2. Shared Postgres cluster with two schemas (proposed) vs separate DBs?
3. Which backend owns `tenant_id` authority?
4. Plan to port any NestJS module to Django or vice versa?
5. Is top-level `/frontend/` salvageable or should it be removed?

## Test plan

- [ ] Review ADR-0004 for factual accuracy — especially the routing table and the "overlap" list in `architecture-dual-backend.md`.
- [ ] Confirm the 5 open questions are the right set before this ADR is ratified.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)