### PR TITLE
docs: rewrite CLAUDE.md and README for dual-backend reality (closes #112)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,101 @@
-# ManufacturingOS - Claude Code Configuration
+# ManufacturingOS — Claude Code Configuration
 
-This project has Claude Code capabilities configured for optimal AI-assisted development.
+This project has Claude Code capabilities configured for AI-assisted development. **Read [`docs/architecture-dual-backend.md`](docs/architecture-dual-backend.md) before making changes** — the system has two backends, and routing work to the wrong one is a common onboarding mistake.
 
 ## Project Overview
 
-**ManufacturingOS** is a full-stack ERP system for manufacturing operations.
+**ManufacturingOS** is a full-stack ERP system for manufacturing operations, with a layered multi-industry architecture. The first customer is B3 MACBIS (kitchen equipment).
 
-### Tech Stack
-- **Frontend**: Next.js 14 + React 18 + TypeScript + TailwindCSS + Radix UI
-- **Backend**: NestJS 10 + TypeORM + PostgreSQL
-- **Architecture**: Monorepo (`b3-erp/frontend`, `b3-erp/backend`)
+## Tech Stack (dual-backend)
+
+The system runs **two backends** concurrently, with one frontend that routes to both. See [ADR-0004](docs/adr/0004-dual-backend-django-and-nestjs.md) for the detailed ownership split.
+
+### OptiForge platform — Django
+- **Path:** [`/backend/`](backend/)
+- **Stack:** Django 4.2 + DRF + PostgreSQL 15 + Celery + RabbitMQ + Redis
+- **Owns:** Tenancy, Identity, Audit, Extensions, Events, Workflow, Notifications, Reporting, Documents, Integration, API Gateway, Observability, Localisation, OptiForge Core (21 modules), Modes (ETO, Discrete), Compliance packs, Industry packs (KitchenEquipment)
+- **Port:** 8000
+- **Architecture:** five-layer (Platform → Core → Modes → Compliance → Packs), enforced by `lint-imports`. See [`docs/architecture.md`](docs/architecture.md) and [ADR-0001](docs/adr/0001-five-layer-architecture.md).
+
+### b3-erp domain services — NestJS
+- **Path:** [`/b3-erp/backend/`](b3-erp/backend/)
+- **Stack:** NestJS 10 + TypeORM + PostgreSQL 15
+- **Owns:** HR (statutory, training, loans, bonuses, skills), CRM, Sales (MACBIS flow), CPQ, Procurement, Inventory, Logistics, Finance, Production, Project management, Quality, Approvals, Workflow (MACBIS-specific), Common-masters, Accounts, After-sales, CMS, Estimation, IT-admin, Proposals, Reports, Support
+- **Port:** 3001
+
+### Frontend — Next.js
+- **Path:** [`/b3-erp/frontend/`](b3-erp/frontend/) — the live, feature-complete UI (1,719 pages, 2,389 `.tsx` files)
+- **Stack:** Next.js 14 + React 18 + TypeScript + TailwindCSS + shadcn + Radix UI
+- **API routing:** two base URLs via env vars:
+  - `NEXT_PUBLIC_PLATFORM_API_URL` → Django (port 8000, `/api/v1`)
+  - `NEXT_PUBLIC_DOMAIN_API_URL` → NestJS (port 3001)
+- **Auth:** JWT issued by Keycloak (see [ADR-0003](docs/adr/0003-oidc-provider-keycloak.md)); both backends validate the same token.
+
+### Scaffolds (do not develop against)
+- [`/frontend/`](frontend/) — 6 `.tsx` files, appears to be a boilerplate scaffold. Do not add features here without consulting ADR-0004 question Q5.
+- [`/b3-erp/backend/prisma/`](b3-erp/backend/prisma/) — Prisma module coexists with TypeORM. Default to TypeORM for new entities unless the module is already Prisma.
+
+## Development Commands
+
+Preferred path: docker-compose (brings up both backends + Postgres + Redis + RabbitMQ in the right topology — see [`docker-compose.yml`](docker-compose.yml)).
+
+```bash
+# Full stack via docker-compose
+cp .env.example .env         # edit as needed
+docker-compose up -d
+
+# --- or run components individually ---
+
+# Django backend (OptiForge platform)
+cd backend
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python manage.py migrate
+python manage.py runserver   # :8000
+
+# NestJS backend (b3-erp domain services)
+cd b3-erp/backend
+npm ci
+npm run start:dev            # :3001
+
+# Frontend (the real UI)
+cd b3-erp/frontend
+npm ci
+npm run dev                  # :3000
+```
+
+## Key Directories
+
+**Django (OptiForge platform)**
+- [`/backend/optiforge/platform/`](backend/optiforge/platform/) — 13 platform services (tenancy, identity, audit, extensions, events, workflow, notifications, reporting, documents, integration, api_gateway, observability, localisation)
+- [`/backend/optiforge/core/`](backend/optiforge/core/) — 21 core modules (CRM, Sales, Procurement, Inventory, WMS, Project, HR, PLM, IT-Admin, S&OP, CMMS, EHS, Production Planning, MES, Finance, QMS, Analytics, Field Service, Commissioning, Logistics, Support)
+- [`/backend/optiforge/modes/`](backend/optiforge/modes/) — Mode extensions (ETO, Discrete; scaffolded: Process, Job-Shop, Repetitive, Mixed)
+- [`/backend/optiforge/compliance/`](backend/optiforge/compliance/) — Compliance layer scaffolding
+- [`/backend/optiforge/packs/`](backend/optiforge/packs/) — Industry packs (KitchenEquipment)
+- [`/backend/tests/`](backend/tests/) — 14 pytest modules across canary/contract/performance/dr_drill/second_pack/acero/scaffolded_mode
+
+**NestJS (b3-erp domain services)**
+- [`/b3-erp/backend/src/modules/`](b3-erp/backend/src/modules/) — 29 domain modules
+- [`/b3-erp/backend/src/common/`](b3-erp/backend/src/common/) — Cross-cutting decorators, filters, interceptors, guards
+- [`/b3-erp/backend/test/unit/`](b3-erp/backend/test/unit/) — Jest unit specs
+
+**Frontend**
+- [`/b3-erp/frontend/src/app/`](b3-erp/frontend/src/app/) — Next.js App Router pages (1,719 pages)
+- [`/b3-erp/frontend/src/components/`](b3-erp/frontend/src/components/) — React components
+- [`/b3-erp/frontend/src/services/`](b3-erp/frontend/src/services/) — Typed API clients; each file picks **exactly one** of the two backend base URLs
+- [`/b3-erp/frontend/src/lib/api-client.ts`](b3-erp/frontend/src/lib/api-client.ts) — Axios instance for Django platform
+- [`/b3-erp/frontend/src/context/AuthContext.tsx`](b3-erp/frontend/src/context/AuthContext.tsx) — JWT/Keycloak flow
+
+## Where Things Live — Quick Rules
+
+- **New platform feature (auth, audit, workflow, tenancy, extensions):** Django. Add an app under `optiforge/platform/` and update settings.
+- **New OptiForge core module (demand planning, MES, CPQ flows, scheduling, etc.):** Django, under `optiforge/core/<module>/`.
+- **New MACBIS/domain feature (HR sub-flow, CRM process, estimation rule, etc.):** NestJS, under `b3-erp/backend/src/modules/<module>/`.
+- **Cross-cutting concerns that must stay identical in both backends** (audit columns, soft delete, pagination, error envelope, JWT claims): document in [`docs/architecture-dual-backend.md`](docs/architecture-dual-backend.md) under "Data contracts" and implement in both.
 
 ## Enabled Capabilities
 
-The following Claude capabilities are enabled for this project:
+The following Claude capabilities are configured for this project:
 
 | Capability | Description |
 |------------|-------------|
@@ -28,41 +110,16 @@ The following Claude capabilities are enabled for this project:
 | `backend-engineer` | Database schemas, APIs, frontend-backend wiring |
 | `quality-assurance-engineer` | Testing, QA processes, automation |
 
-## Capability Documentation
+Detailed capability documentation lives in [`.claude/capabilities/`](.claude/capabilities/).
 
-Detailed documentation for each capability is in `.claude/capabilities/`:
+## Status
 
-```
-.claude/
-├── settings.json
-└── capabilities/
-    ├── workflow-manager.md
-    ├── ai-automation.md
-    ├── platform-capabilities.md
-    ├── developer-guidelines.md
-    ├── business-ops-marketing-manager.md
-    ├── linkedin-expert.md
-    ├── kreupai-solution-architect.md
-    ├── landing-page-developer.md
-    ├── backend-engineer.md
-    └── quality-assurance-engineer.md
-```
+Phases 1–6 have merged into `main`. See the PR list for detail: [`feat(phase-1)` … `feat(phase-6)`](https://github.com/boscosabujohn/ManufacturingOS/pulls?q=is%3Apr+phase+merged%3Atrue). The README "Status" table is the source of truth for phase-level progress.
 
-## Development Commands
+## Further Reading
 
-```bash
-# Start backend
-cd b3-erp/backend && npm run start:dev
-
-# Start frontend
-cd b3-erp/frontend && npm run dev
-
-# Run with Docker
-docker-compose up -d
-```
-
-## Key Directories
-
-- `/b3-erp/backend/src/modules/` - Backend modules (HR, Sales, Production, etc.)
-- `/b3-erp/frontend/src/app/` - Next.js pages
-- `/b3-erp/frontend/src/components/` - React components
+- [README.md](README.md) — overview + getting-started
+- [ADR-0004: Dual-backend architecture](docs/adr/0004-dual-backend-django-and-nestjs.md) — why two backends, what owns what
+- [docs/architecture-dual-backend.md](docs/architecture-dual-backend.md) — live-system diagram, routing rules, shared contracts
+- [docs/architecture.md](docs/architecture.md) — OptiForge layered architecture (Django-internal)
+- [docs/README.md](docs/README.md) — index of all project documentation

--- a/README.md
+++ b/README.md
@@ -2,18 +2,25 @@
 
 **A layered multi-industry manufacturing ERP.** OptiForge is structured as five layers — Platform → Core → Modes → Compliance → Industry Packs — with a strict core/pack seam: every layer depends only on layers below it, and industry-specific logic lives exclusively in packs. B3 MACBIS kitchen equipment is the first customer and the KitchenEquipment pack is the only industry pack shipping in v1.
 
-This repo holds the monorepo: Django + DRF + PostgreSQL 15 backend, Next.js 14 + TypeScript + shadcn frontend, Celery + RabbitMQ + Redis for background work.
+This repo holds the monorepo. The running system has **two backends**:
+
+- **OptiForge (Django + DRF + PostgreSQL 15)** at [`/backend/`](backend/) — platform services (tenancy, identity, audit, extensions, events, workflow, notifications, reporting, documents, integration, api_gateway, observability, localisation), plus the OptiForge layered Core/Modes/Compliance/Packs stack. Celery + RabbitMQ + Redis for background work.
+- **b3-erp (NestJS 10 + TypeORM)** at [`/b3-erp/backend/`](b3-erp/backend/) — 29 domain services (HR, CRM, Sales, Procurement, Inventory, Finance, Production, Logistics, Project-mgmt, Quality, Approvals, …).
+
+The feature-complete frontend is **[`/b3-erp/frontend/`](b3-erp/frontend/)** (Next.js 14 + TypeScript + shadcn, 1,719 pages). It routes to both backends via two base URLs (`NEXT_PUBLIC_PLATFORM_API_URL`, `NEXT_PUBLIC_DOMAIN_API_URL`). See [ADR-0004](docs/adr/0004-dual-backend-django-and-nestjs.md) and [`docs/architecture-dual-backend.md`](docs/architecture-dual-backend.md) for the full ownership split and live-system diagram.
 
 ---
 
 ## For a new developer: read these, in order
 
-1. [`docs/README.md`](./docs/README.md) — index of all project documentation.
-2. [`docs/brainstorms/2026-04-23-optiforge-layered-multi-industry.md`](./docs/brainstorms/2026-04-23-optiforge-layered-multi-industry.md) — why the architecture is layered, what was rejected, open questions resolved.
-3. [`docs/prds/optiforge-layered-multi-industry-architecture.md`](./docs/prds/optiforge-layered-multi-industry-architecture.md) — the Product Requirements Document. The source of truth every issue references.
-4. [`docs/plans/optiforge-layered-multi-industry-architecture.md`](./docs/plans/optiforge-layered-multi-industry-architecture.md) — the phased build plan. Phase 1 is the tracer bullet; start there.
-5. [`docs/adr/README.md`](./docs/adr/README.md) — decisions log. Read before making an architectural choice; add an ADR before committing one.
-6. [`docs/runbooks/phase-1-kickoff-checklist.md`](./docs/runbooks/phase-1-kickoff-checklist.md) — what must be decided and done before anyone picks up issue P1-01.
+1. [`docs/architecture-dual-backend.md`](./docs/architecture-dual-backend.md) — live-system diagram, which backend owns what, routing rules. **Start here.**
+2. [`docs/adr/0004-dual-backend-django-and-nestjs.md`](./docs/adr/0004-dual-backend-django-and-nestjs.md) — why two backends, what decisions are settled, what's still open.
+3. [`docs/README.md`](./docs/README.md) — index of all project documentation.
+4. [`docs/brainstorms/2026-04-23-optiforge-layered-multi-industry.md`](./docs/brainstorms/2026-04-23-optiforge-layered-multi-industry.md) — why the OptiForge architecture is layered, what was rejected, open questions resolved.
+5. [`docs/prds/optiforge-layered-multi-industry-architecture.md`](./docs/prds/optiforge-layered-multi-industry-architecture.md) — the Product Requirements Document. The source of truth every issue references.
+6. [`docs/plans/optiforge-layered-multi-industry-architecture.md`](./docs/plans/optiforge-layered-multi-industry-architecture.md) — the phased build plan.
+7. [`docs/adr/README.md`](./docs/adr/README.md) — decisions log. Read before making an architectural choice; add an ADR before committing one.
+8. [`docs/runbooks/phase-1-kickoff-checklist.md`](./docs/runbooks/phase-1-kickoff-checklist.md) — what must be decided and done before anyone picks up issue P1-01.
 
 The GitHub issues (labelled `phase:1`..`phase:5`) are the unit of work. Issues reference the PRD and plan; the PRD and plan reference the brainstorm. Nothing references code paths or file locations because those go stale.
 
@@ -42,21 +49,42 @@ Cross-layer import violations are strictly forbidden and enforced by CI linters.
 
 ## Getting started
 
+Preferred path: docker-compose brings up both backends + frontend + Postgres + Redis + RabbitMQ in the right topology.
+
 ```bash
 # Clone
 git clone https://github.com/boscosabujohn/ManufacturingOS.git
 cd ManufacturingOS
 
-# Backend
+# Configure env
+cp .env.example .env          # edit as needed
+
+# Full stack
+docker-compose up -d
+
+# Frontend:  http://localhost:3000
+# Django:    http://localhost:8000/api/v1
+# NestJS:    http://localhost:3001
+```
+
+To run components individually:
+
+```bash
+# Django backend (OptiForge platform) — port 8000
 cd backend
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt  # Or install dependencies manually as required
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python manage.py migrate
 python manage.py runserver
 
-# Frontend
-cd ../frontend
-npm install
+# NestJS backend (b3-erp domain services) — port 3001
+cd b3-erp/backend
+npm ci
+npm run start:dev
+
+# Frontend — port 3000
+cd b3-erp/frontend
+npm ci
 npm run dev
 ```
 
@@ -72,12 +100,12 @@ npm run dev
 
 ## Status
 
-| | |
+| Phase | Status |
 |---|---|
-| **Phase 1 (Tracer Bullet)** | Not started |
-| **Phase 2 (Platform Depth)** | Not started |
-| **Phase 3 (Demand + Design Half)** | Not started |
-| **Phase 4 (Execution Half + Migration)** | Not started |
-| **Phase 5 (Hardening + Go-Live)** | Not started |
-
-First milestone: complete P1-01 (scaffolding + cross-layer lint canary).
+| **Phase 1 (Tracer Bullet)** | ✅ Merged ([#106](https://github.com/boscosabujohn/ManufacturingOS/pull/106)) |
+| **Phase 2 (Platform Depth)** | ✅ Merged ([#107](https://github.com/boscosabujohn/ManufacturingOS/pull/107)) |
+| **Phase 3 (Demand + Design Half)** | ✅ Merged ([#108](https://github.com/boscosabujohn/ManufacturingOS/pull/108)) |
+| **Phase 4 (Execution Half + Migration)** | ✅ Merged ([#109](https://github.com/boscosabujohn/ManufacturingOS/pull/109)) |
+| **Phase 5 (Hardening + Go-Live)** | ✅ Merged ([#110](https://github.com/boscosabujohn/ManufacturingOS/pull/110)) |
+| **Phase 6 (Celery publisher + BOQ upload UI)** | ✅ Merged ([#111](https://github.com/boscosabujohn/ManufacturingOS/pull/111)) |
+| **Backend-improvement milestone** | 🔄 In progress ([milestone 2](https://github.com/boscosabujohn/ManufacturingOS/milestone/2)) — docs, soft-delete/audit, pagination, compose, CI across both backends |


### PR DESCRIPTION
## Summary

- **CLAUDE.md** rewritten from NestJS-only to dual-backend. Adds "Where Things Live" quick rules so new features are routed to the right backend, and adds a "Scaffolds (do not develop against)" section flagging `/frontend/` and the Prisma module.
- **README.md** rewritten to describe both backends, point new developers to [`docs/architecture-dual-backend.md`](../blob/feature/backend-improvement-112-docs/docs/architecture-dual-backend.md) first, and fix the Status table (Phases 1-6 merged, backend-improvement in progress).

## Dependency

Depends on [#118](https://github.com/boscosabujohn/ManufacturingOS/pull/119) (ADR-0004). Merge #119 first — the CLAUDE.md and README rewrites reference the ADR and the architecture diagram it introduces.

## Test plan

- [ ] Links in the docs resolve correctly once both PRs are merged.
- [ ] The "Where Things Live" quick rules in CLAUDE.md match the ownership table in ADR-0004.
- [ ] Status table dates match the merged PRs listed on the merge page.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)