### PR TITLE
feat(devops): real docker-compose for full dual-backend stack (closes #115)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,80 @@
+# ManufacturingOS — example environment file.
+# Copy to `.env` at the repo root: `cp .env.example .env`
+# `.env` is gitignored. Do NOT commit secrets.
+
+# -------------------------------------------------------------------
+# Shared infrastructure
+# -------------------------------------------------------------------
+
+# PostgreSQL (one cluster; Django and NestJS use separate schemas per ADR-0004)
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_USER=manufacturingos
+POSTGRES_PASSWORD=change-me-in-local-and-prod
+POSTGRES_DB=manufacturingos
+
+# Redis (Celery result backend, caching)
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_URL=redis://redis:6379/0
+
+# RabbitMQ (Celery broker, event bus)
+RABBITMQ_HOST=rabbitmq
+RABBITMQ_USER=manufacturingos
+RABBITMQ_PASSWORD=change-me-in-local-and-prod
+RABBITMQ_VHOST=manufacturingos
+CELERY_BROKER_URL=amqp://manufacturingos:change-me-in-local-and-prod@rabbitmq:5672/manufacturingos
+
+# -------------------------------------------------------------------
+# OptiForge — Django backend (port 8000)
+# -------------------------------------------------------------------
+
+# Django
+DJANGO_SETTINGS_MODULE=optiforge.settings
+# Generate a real one for any non-local env: `python -c "import secrets; print(secrets.token_urlsafe(64))"`
+DJANGO_SECRET_KEY=django-insecure-change-me-before-any-non-local-env
+DJANGO_DEBUG=True
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,django-backend
+DJANGO_CORS_ALLOWED_ORIGINS=http://localhost:3000
+
+# Database — values come from the shared block above; Django reads these
+DATABASE_HOST=${POSTGRES_HOST}
+DATABASE_PORT=${POSTGRES_PORT}
+DATABASE_USER=${POSTGRES_USER}
+DATABASE_PASSWORD=${POSTGRES_PASSWORD}
+DATABASE_NAME=${POSTGRES_DB}
+DATABASE_SCHEMA=optiforge
+
+# JWT (validated against Keycloak JWKS; see ADR-0003)
+JWT_SECRET=optiforge-dev-secret-change-in-production-32bytes!
+KEYCLOAK_ISSUER_URL=http://keycloak:8080/realms/manufacturingos
+KEYCLOAK_JWKS_URL=http://keycloak:8080/realms/manufacturingos/protocol/openid-connect/certs
+
+# -------------------------------------------------------------------
+# b3-erp — NestJS backend (port 3001)
+# -------------------------------------------------------------------
+
+NESTJS_PORT=3001
+NESTJS_JWT_SECRET=nestjs-dev-secret-change-in-production-32bytes!
+
+# Same cluster, different schema per ADR-0004 §5
+NESTJS_DATABASE_HOST=${POSTGRES_HOST}
+NESTJS_DATABASE_PORT=${POSTGRES_PORT}
+NESTJS_DATABASE_USER=${POSTGRES_USER}
+NESTJS_DATABASE_PASSWORD=${POSTGRES_PASSWORD}
+NESTJS_DATABASE_NAME=${POSTGRES_DB}
+NESTJS_DATABASE_SCHEMA=b3_erp
+
+# -------------------------------------------------------------------
+# Frontend — b3-erp/frontend (port 3000)
+# -------------------------------------------------------------------
+
+# Public vars are baked into the Next.js bundle at build time.
+NEXT_PUBLIC_PLATFORM_API_URL=http://localhost:8000/api/v1
+NEXT_PUBLIC_DOMAIN_API_URL=http://localhost:3001
+NEXT_PUBLIC_KEYCLOAK_URL=http://localhost:8080
+
+# Legacy single-var name — kept while the codebase migrates to the
+# split above. New service files MUST use one of the two PLATFORM/DOMAIN
+# vars. See docs/architecture-dual-backend.md.
+NEXT_PUBLIC_API_URL=http://localhost:8000/api/v1

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 
+# Local docker-compose override (copy of docker-compose.override.yml.example)
+docker-compose.override.yml
+
 # Vercel
 .vercel
 

--- a/b3-erp/docker/backend/Dockerfile
+++ b/b3-erp/docker/backend/Dockerfile
@@ -30,12 +30,13 @@ COPY --from=builder /app/dist ./dist
 # Alpine already has a 'node' user
 USER node
 
-# Expose backend port
-EXPOSE 8000
+# Expose backend port (NestJS reads PORT env var at runtime; default 3001 per ADR-0004).
+ENV PORT=3001
+EXPOSE 3001
 
-# Health check using Terminus endpoint
+# Health check using Terminus endpoint on $PORT
 HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
-  CMD node -e "fetch('http://localhost:8000/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"
+  CMD node -e "fetch('http://localhost:' + (process.env.PORT || 3001) + '/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"
 
 # Run the application
 CMD ["node", "dist/main"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,56 @@
+# OptiForge Django backend — multi-stage Dockerfile.
+# Build stage installs deps; final stage copies only what's needed to run.
+
+# ---------- Build stage ----------
+FROM python:3.11-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /build
+
+# System deps for building psycopg2 and similar wheels
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --upgrade pip && \
+    pip install --prefix=/install -r requirements.txt
+
+# ---------- Runtime stage ----------
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    DJANGO_SETTINGS_MODULE=optiforge.settings
+
+# Runtime-only system deps (no -dev packages)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpq5 \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root user
+RUN groupadd -r app && useradd -r -g app -d /app -s /sbin/nologin app
+WORKDIR /app
+
+# Copy installed python packages from builder
+COPY --from=builder /install /usr/local
+
+# Copy application source
+COPY --chown=app:app . /app
+
+USER app
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:8000/api/v1/health/ || exit 1
+
+CMD ["gunicorn", "optiforge.wsgi:application", \
+     "--bind", "0.0.0.0:8000", \
+     "--workers", "3", \
+     "--timeout", "60"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,30 @@
+# OptiForge Django backend — runtime + dev dependencies.
+# Pin only majors + minors where churn is common; leave patch floating.
+
+# Core framework
+Django~=4.2.0
+djangorestframework~=3.14.0
+
+# Auth / JWT
+PyJWT~=2.8.0
+
+# Database
+psycopg2-binary~=2.9.0
+
+# Background work (ADR-0002: Celery + RabbitMQ + Redis)
+celery~=5.3.0
+redis~=5.0.0
+kombu~=5.3.0
+
+# Cross-origin for the Next.js frontend at :3000
+django-cors-headers~=4.3.0
+
+# Production WSGI server
+gunicorn~=21.2.0
+
+# --- Dev / test ---
+pytest~=7.4.0
+pytest-django~=4.7.0
+pytest-cov~=4.1.0
+mypy~=1.7.0
+import-linter~=2.0

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,42 @@
+# ManufacturingOS — local-dev overrides.
+# Copy to docker-compose.override.yml (gitignored) and edit as needed.
+# Docker Compose merges this file on top of docker-compose.yml automatically.
+#
+# Typical uses:
+#   - mount source for hot reload
+#   - expose debug ports (Django runserver, Node inspector)
+#   - swap production CMD for a dev CMD
+
+services:
+  django-backend:
+    command: python manage.py runserver 0.0.0.0:8000
+    environment:
+      DJANGO_DEBUG: "True"
+    volumes:
+      - ./backend:/app
+    # Keep the exposed host port on 8000 (already in base file).
+
+  nestjs-backend:
+    # For hot reload, run the dev server and bind-mount source.
+    command: npm run start:dev
+    environment:
+      NODE_ENV: development
+    volumes:
+      - ./b3-erp/backend:/app
+      # Preserve the image's node_modules (already-installed) when bind mount shadows /app
+      - /app/node_modules
+
+  frontend:
+    command: npm run dev
+    environment:
+      NODE_ENV: development
+    volumes:
+      - ./b3-erp/frontend:/app
+      - /app/node_modules
+      - /app/.next
+
+  postgres:
+    # Expose on the host's default Postgres port 5432 if nothing else has it.
+    # Comment out if you already run a Postgres on 5432 — the base file's 5433 mapping stays.
+    # ports:
+    #   - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,176 @@
-version: '3.8'
+# ManufacturingOS — full-stack docker-compose.
+# See docs/architecture-dual-backend.md for the topology this models.
+#
+# Services:
+#   postgres          single cluster, two logical schemas (optiforge.*, b3_erp.*)
+#   redis             cache + Celery result backend
+#   rabbitmq          Celery broker + event bus
+#   django-backend    OptiForge platform (port 8000)
+#   django-celery     Celery worker for Django
+#   django-celery-beat  Celery scheduler for Django
+#   nestjs-backend    b3-erp domain services (port 3001)
+#   frontend          b3-erp/frontend Next.js (port 3000)
+#
+# Usage:
+#   cp .env.example .env          # edit as needed
+#   docker-compose up -d          # full stack
+#   docker-compose up postgres    # just Postgres (matches old compose behaviour)
+#
+# For local-dev overrides (source mounts, debug ports), copy
+# docker-compose.override.yml.example to docker-compose.override.yml.
+
 services:
   postgres:
     image: postgres:15
     environment:
-      POSTGRES_USER: test
-      POSTGRES_PASSWORD: test
-      POSTGRES_DB: test_db
+      POSTGRES_USER: ${POSTGRES_USER:-manufacturingos}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change-me-in-local-and-prod}
+      POSTGRES_DB: ${POSTGRES_DB:-manufacturingos}
     ports:
+      # Expose on 5433 externally to avoid clashing with a host Postgres on 5432.
       - "5433:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./scripts/init-schemas.sql:/docker-entrypoint-initdb.d/init-schemas.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-manufacturingos} -d ${POSTGRES_DB:-manufacturingos}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-manufacturingos}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-change-me-in-local-and-prod}
+      RABBITMQ_DEFAULT_VHOST: ${RABBITMQ_VHOST:-manufacturingos}
+    ports:
+      - "5672:5672"   # AMQP
+      - "15672:15672" # management UI
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  django-backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    environment:
+      DJANGO_SETTINGS_MODULE: optiforge.settings
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+      DJANGO_DEBUG: ${DJANGO_DEBUG:-True}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost,127.0.0.1,django-backend}
+      DJANGO_CORS_ALLOWED_ORIGINS: ${DJANGO_CORS_ALLOWED_ORIGINS:-http://localhost:3000}
+      DATABASE_HOST: postgres
+      DATABASE_PORT: 5432
+      DATABASE_USER: ${POSTGRES_USER:-manufacturingos}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-change-me-in-local-and-prod}
+      DATABASE_NAME: ${POSTGRES_DB:-manufacturingos}
+      REDIS_URL: redis://redis:6379/0
+      CELERY_BROKER_URL: amqp://${RABBITMQ_USER:-manufacturingos}:${RABBITMQ_PASSWORD:-change-me-in-local-and-prod}@rabbitmq:5672/${RABBITMQ_VHOST:-manufacturingos}
+      JWT_SECRET: ${JWT_SECRET:-optiforge-dev-secret-change-in-production-32bytes!}
+    ports:
+      - "8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+
+  django-celery:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    command: celery -A optiforge worker --loglevel=info
+    environment:
+      DJANGO_SETTINGS_MODULE: optiforge.settings
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+      DATABASE_HOST: postgres
+      DATABASE_USER: ${POSTGRES_USER:-manufacturingos}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-change-me-in-local-and-prod}
+      DATABASE_NAME: ${POSTGRES_DB:-manufacturingos}
+      REDIS_URL: redis://redis:6379/0
+      CELERY_BROKER_URL: amqp://${RABBITMQ_USER:-manufacturingos}:${RABBITMQ_PASSWORD:-change-me-in-local-and-prod}@rabbitmq:5672/${RABBITMQ_VHOST:-manufacturingos}
+    depends_on:
+      django-backend:
+        condition: service_started
+
+  django-celery-beat:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    command: celery -A optiforge beat --loglevel=info
+    environment:
+      DJANGO_SETTINGS_MODULE: optiforge.settings
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+      DATABASE_HOST: postgres
+      DATABASE_USER: ${POSTGRES_USER:-manufacturingos}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-change-me-in-local-and-prod}
+      DATABASE_NAME: ${POSTGRES_DB:-manufacturingos}
+      REDIS_URL: redis://redis:6379/0
+      CELERY_BROKER_URL: amqp://${RABBITMQ_USER:-manufacturingos}:${RABBITMQ_PASSWORD:-change-me-in-local-and-prod}@rabbitmq:5672/${RABBITMQ_VHOST:-manufacturingos}
+    depends_on:
+      django-backend:
+        condition: service_started
+
+  nestjs-backend:
+    build:
+      context: ./b3-erp/backend
+      dockerfile: ../docker/backend/Dockerfile
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
+      PORT: ${NESTJS_PORT:-3001}
+      DATABASE_HOST: postgres
+      DATABASE_PORT: 5432
+      DATABASE_USER: ${POSTGRES_USER:-manufacturingos}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-change-me-in-local-and-prod}
+      DATABASE_NAME: ${POSTGRES_DB:-manufacturingos}
+      DATABASE_SCHEMA: ${NESTJS_DATABASE_SCHEMA:-b3_erp}
+      JWT_SECRET: ${NESTJS_JWT_SECRET:-nestjs-dev-secret-change-in-production-32bytes!}
+      REDIS_URL: redis://redis:6379/1
+    ports:
+      - "3001:3001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  frontend:
+    build:
+      context: ./b3-erp/frontend
+      dockerfile: ../docker/frontend/Dockerfile
+      args:
+        NEXT_PUBLIC_PLATFORM_API_URL: ${NEXT_PUBLIC_PLATFORM_API_URL:-http://localhost:8000/api/v1}
+        NEXT_PUBLIC_DOMAIN_API_URL: ${NEXT_PUBLIC_DOMAIN_API_URL:-http://localhost:3001}
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8000/api/v1}
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
+    ports:
+      - "3000:3000"
+    depends_on:
+      - django-backend
+      - nestjs-backend
+
+volumes:
+  postgres-data:
+  redis-data:
+  rabbitmq-data:

--- a/scripts/init-schemas.sql
+++ b/scripts/init-schemas.sql
@@ -1,0 +1,16 @@
+-- Postgres schema initialisation for ManufacturingOS (ADR-0004).
+-- One physical database, two logical schemas; Django owns `optiforge.*`,
+-- NestJS owns `b3_erp.*`. Cross-schema reads via views are allowed; writes are not.
+--
+-- This file runs exactly once, on first-init of the postgres container volume.
+-- To re-run: `docker-compose down -v` (deletes the volume), then `up` again.
+
+CREATE SCHEMA IF NOT EXISTS optiforge;
+CREATE SCHEMA IF NOT EXISTS b3_erp;
+
+-- Default search_path puts the most-used schema first for each backend.
+-- Each backend overrides this via its own connection settings (search_path
+-- in DATABASES for Django, schema option on TypeORM DataSource for NestJS).
+
+COMMENT ON SCHEMA optiforge IS 'OptiForge (Django) — platform + core + modes + compliance + packs. See ADR-0004.';
+COMMENT ON SCHEMA b3_erp   IS 'b3-erp (NestJS) — 29 domain services. See ADR-0004.';


### PR DESCRIPTION
## Summary

- **docker-compose.yml** rewritten from Postgres-only to the full dual-backend topology from ADR-0004: Django + Celery worker + Celery beat, NestJS backend, Next.js frontend, Postgres (with pre-created `optiforge.*` and `b3_erp.*` schemas), Redis, RabbitMQ.
- **`backend/Dockerfile`** added — multi-stage, non-root, gunicorn CMD, healthcheck on `/api/v1/health/`.
- **`backend/requirements.txt`** added — pinned-major deps for Django + DRF + Celery + Postgres + JWT + Gunicorn + CORS + test tooling.
- **`.env.example`** added — every env var the stack reads, safe placeholders, NEXT_PUBLIC_PLATFORM/DOMAIN split per ADR-0004.
- **`docker-compose.override.yml.example`** — local-dev variant with source mounts and dev CMDs.
- **`scripts/init-schemas.sql`** — creates both schemas on first container boot.
- **Fix** `b3-erp/docker/backend/Dockerfile`: hardcoded `EXPOSE 8000` + healthcheck on `:8000` wouldn't work when NestJS runs on `:3001`. Now respects `PORT` env var (default `3001`).
- **`.gitignore`**: ignore the local-only `docker-compose.override.yml` copy.

## Validation

`docker compose config --quiet` exits 0 after these changes.

## Dependency

This PR encodes the ADR-0004 topology (two backends, shared Postgres cluster, two schemas). Merge [#119](https://github.com/boscosabujohn/ManufacturingOS/pull/119) first so the referenced topology is documented.

## Test plan

- [ ] `cp .env.example .env && docker-compose up -d postgres redis rabbitmq` — infra services come up healthy.
- [ ] `docker-compose up -d django-backend` — Django image builds and `curl http://localhost:8000/api/v1/health/` returns 200 (once a health endpoint exists — currently a TODO).
- [ ] `docker-compose up -d nestjs-backend` — NestJS image builds (re-uses `b3-erp/docker/backend/Dockerfile`) and `curl http://localhost:3001/health` returns 200.
- [ ] `docker-compose up -d frontend` — frontend builds and serves on 3000.
- [ ] `cp docker-compose.override.yml.example docker-compose.override.yml && docker-compose up django-backend nestjs-backend frontend` — edits to source hot-reload correctly.

## Follow-ups

- A Django `/api/v1/health/` endpoint doesn't yet exist — the healthcheck will fail until one is added (tracked in the runbooks work per the PRD).
- Keycloak is referenced in `.env.example` but not yet a compose service. Add in a later PR when identity/OIDC work lands.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)