### PR TITLE
feat(data): shared audit + soft-delete contract on both backends (closes #113)

### DIFF
--- a/b3-erp/backend/src/common/entities/base.entity.ts
+++ b/b3-erp/backend/src/common/entities/base.entity.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared base entities for the NestJS domain services.
+ *
+ * ADR-0004 §"Obligations accepted" pins audit + soft-delete semantics as
+ * shared contracts across the two backends. The Django counterpart lives at
+ * `backend/optiforge/platform/tenancy/mixins.py`; the semantics here must
+ * stay aligned with it.
+ *
+ * New entities SHOULD extend {@link AuditedEntity} (or
+ * {@link TenantAuditedEntity} if tenant-scoped). Existing entities may be
+ * migrated incrementally; adoption is tracked as a follow-up to issue #113.
+ */
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * UUID primary key + audit columns.
+ *
+ * Columns:
+ *  - id           UUID v4, primary key.
+ *  - createdAt    timestamp, set on insert.
+ *  - updatedAt    timestamp, set on every save.
+ *  - createdBy    UUID (nullable), typically the JWT sub of the actor.
+ *  - updatedBy    UUID (nullable), last actor to mutate the row.
+ *  - deletedAt    timestamp (nullable), set by TypeORM soft-delete.
+ *  - deletedBy    UUID (nullable), set explicitly via softDelete(entity, userId).
+ *
+ * Soft delete is driven by TypeORM's {@link DeleteDateColumn}. Default
+ * finds (repo.find, repo.findOne) automatically exclude rows where
+ * deletedAt IS NOT NULL. To include them use `repo.find({ withDeleted: true })`.
+ *
+ * To soft-delete a row, prefer `repo.softRemove(entity)` or
+ * `repo.softDelete(id)`. Call {@link markDeletedBy} first if you need to
+ * attribute the deletion to a user.
+ */
+export abstract class AuditedEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt!: Date;
+
+  @Column({ type: 'uuid', nullable: true })
+  createdBy!: string | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  updatedBy!: string | null;
+
+  @DeleteDateColumn({ type: 'timestamptz' })
+  deletedAt!: Date | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  deletedBy!: string | null;
+
+  /**
+   * Stamp the caller onto the row before a soft-delete. Call this then
+   * `repo.softRemove(entity)` — the DeleteDateColumn then stamps deletedAt
+   * and the row disappears from default finds.
+   */
+  markDeletedBy(userId: string | null): void {
+    this.deletedBy = userId;
+  }
+
+  /** Convenience accessor matching the Django `is_deleted` property. */
+  get isDeleted(): boolean {
+    return this.deletedAt !== null && this.deletedAt !== undefined;
+  }
+}
+
+/**
+ * AuditedEntity + non-nullable tenantId for tenant-scoped domain tables.
+ *
+ * The tenantId is a free-form UUID (not a ForeignKey) because the Tenant
+ * table of record lives in the Django/OptiForge backend. NestJS services
+ * validate and filter by tenantId at the guard/repo layer; they do not
+ * reach across backends to look up the tenant.
+ *
+ * See ADR-0004 Q3 (tenant_id authority) and docs/architecture-dual-backend.md
+ * "Tenant scoping" section.
+ */
+export abstract class TenantAuditedEntity extends AuditedEntity {
+  @Column({ type: 'uuid' })
+  tenantId!: string;
+}

--- a/b3-erp/backend/test/unit/common/base-entity.spec.ts
+++ b/b3-erp/backend/test/unit/common/base-entity.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Contract tests for the shared base entities (AuditedEntity,
+ * TenantAuditedEntity).
+ *
+ * Mirrors backend/tests/audit_soft_delete/test_mixins.py on the Django
+ * side. The columns and semantics must stay aligned per ADR-0004
+ * §"Obligations accepted".
+ *
+ * This spec focuses on the TypeScript-level contract — that the decorators
+ * are in place, the helper methods behave correctly, and the class can be
+ * extended. Full soft-delete integration with TypeORM is exercised in the
+ * per-module integration tests as entities migrate to the base.
+ */
+import 'reflect-metadata';
+import { Entity, Column, getMetadataArgsStorage } from 'typeorm';
+
+import {
+  AuditedEntity,
+  TenantAuditedEntity,
+} from '../../../src/common/entities/base.entity';
+
+// ---------------------------------------------------------------------------
+// A concrete subclass used only in these tests.
+// ---------------------------------------------------------------------------
+
+@Entity({ name: 'test_audited_entities' })
+class DummyAuditedEntity extends AuditedEntity {
+  @Column()
+  name!: string;
+}
+
+@Entity({ name: 'test_tenant_audited_entities' })
+class DummyTenantEntity extends TenantAuditedEntity {
+  @Column()
+  name!: string;
+}
+
+/**
+ * TypeORM's MetadataArgsStorage stores decorator args on the class where
+ * the decorator was actually applied. For inherited columns, the target is
+ * the *parent* abstract class, not the concrete child. This helper walks
+ * the prototype chain and matches either.
+ */
+function findColumn(target: Function, prop: string) {
+  const targets: Function[] = [];
+  let cursor: Function | null = target;
+  while (cursor && cursor !== Function.prototype) {
+    targets.push(cursor);
+    cursor = Object.getPrototypeOf(cursor);
+  }
+  return getMetadataArgsStorage().columns.find(
+    (c) => targets.includes(c.target as Function) && c.propertyName === prop,
+  );
+}
+
+function findGeneration(target: Function, prop: string) {
+  const targets: Function[] = [];
+  let cursor: Function | null = target;
+  while (cursor && cursor !== Function.prototype) {
+    targets.push(cursor);
+    cursor = Object.getPrototypeOf(cursor);
+  }
+  return getMetadataArgsStorage().generations.find(
+    (g) => targets.includes(g.target as Function) && g.propertyName === prop,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AuditedEntity — column contract
+// ---------------------------------------------------------------------------
+
+describe('AuditedEntity column contract', () => {
+  it('registers a primary generated uuid column named id', () => {
+    const gen = findGeneration(DummyAuditedEntity, 'id');
+    expect(gen).toBeDefined();
+    expect(gen?.strategy).toBe('uuid');
+  });
+
+  it('registers createdAt as a CreateDateColumn (timestamptz)', () => {
+    const col = findColumn(DummyAuditedEntity, 'createdAt');
+    expect(col?.mode).toBe('createDate');
+    expect(col?.options.type).toBe('timestamptz');
+  });
+
+  it('registers updatedAt as an UpdateDateColumn (timestamptz)', () => {
+    const col = findColumn(DummyAuditedEntity, 'updatedAt');
+    expect(col?.mode).toBe('updateDate');
+    expect(col?.options.type).toBe('timestamptz');
+  });
+
+  it('registers deletedAt as a DeleteDateColumn (drives soft delete)', () => {
+    const col = findColumn(DummyAuditedEntity, 'deletedAt');
+    expect(col?.mode).toBe('deleteDate');
+    expect(col?.options.type).toBe('timestamptz');
+  });
+
+  it('registers createdBy, updatedBy, deletedBy as nullable uuid columns', () => {
+    for (const prop of ['createdBy', 'updatedBy', 'deletedBy']) {
+      const col = findColumn(DummyAuditedEntity, prop);
+      expect(col).toBeDefined();
+      expect(col?.options.type).toBe('uuid');
+      expect(col?.options.nullable).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AuditedEntity — helpers
+// ---------------------------------------------------------------------------
+
+describe('AuditedEntity helpers', () => {
+  it('isDeleted returns false when deletedAt is null/undefined', () => {
+    const e = new DummyAuditedEntity();
+    e.deletedAt = null;
+    expect(e.isDeleted).toBe(false);
+  });
+
+  it('isDeleted returns true when deletedAt is a Date', () => {
+    const e = new DummyAuditedEntity();
+    e.deletedAt = new Date();
+    expect(e.isDeleted).toBe(true);
+  });
+
+  it('markDeletedBy records the caller user id', () => {
+    const e = new DummyAuditedEntity();
+    e.markDeletedBy('11111111-1111-1111-1111-111111111111');
+    expect(e.deletedBy).toBe('11111111-1111-1111-1111-111111111111');
+  });
+
+  it('markDeletedBy accepts null to clear the attribution', () => {
+    const e = new DummyAuditedEntity();
+    e.deletedBy = 'abc';
+    e.markDeletedBy(null);
+    expect(e.deletedBy).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TenantAuditedEntity — contract
+// ---------------------------------------------------------------------------
+
+describe('TenantAuditedEntity', () => {
+  it('inherits all AuditedEntity columns', () => {
+    for (const prop of [
+      'id',
+      'createdAt',
+      'updatedAt',
+      'createdBy',
+      'updatedBy',
+      'deletedAt',
+      'deletedBy',
+    ]) {
+      const col = findColumn(DummyTenantEntity, prop);
+      const gen = findGeneration(DummyTenantEntity, prop);
+      expect(col ?? gen).toBeDefined();
+    }
+  });
+
+  it('adds a non-nullable tenantId uuid column', () => {
+    const col = findColumn(DummyTenantEntity, 'tenantId');
+    expect(col).toBeDefined();
+    expect(col?.options.type).toBe('uuid');
+    // TypeORM @Column without nullable is non-nullable by default.
+    expect(col?.options.nullable).not.toBe(true);
+  });
+});

--- a/backend/optiforge/platform/tenancy/mixins.py
+++ b/backend/optiforge/platform/tenancy/mixins.py
@@ -1,0 +1,113 @@
+"""
+Cross-cutting mixins for audit columns and soft delete.
+
+ADR-0004 §"Obligations accepted" pins these semantics as shared contracts
+across the two backends. The NestJS counterpart lives in
+`b3-erp/backend/src/common/entities/base.entity.ts`.
+
+Both mixins are abstract models — include them in your model's bases to
+get the columns. Prefer `AuditedTenantModel` (see models.py) for new
+tenant-scoped tables, which composes these with `TenantAwareModel`.
+"""
+from __future__ import annotations
+
+import uuid
+from django.db import models
+
+
+class AuditMixin(models.Model):
+    """
+    Adds the audit columns required by the compliance layer
+    (21 CFR Part 11, IATF 16949, AS9100) — who changed what, when.
+
+    `created_by` and `updated_by` store user UUIDs. We deliberately do
+    not ForeignKey to an auth user model here because:
+      1) The auth user is managed by Keycloak (ADR-0003), not the local DB.
+      2) Audit records must survive user deletion.
+      3) Keeps this mixin usable across platform/core without an
+         identity dependency.
+
+    Populating `created_by` / `updated_by` is the caller's responsibility
+    — typically via the JWT subject in the request context.
+    """
+
+    created_at = models.DateTimeField(auto_now_add=True, db_index=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    created_by = models.UUIDField(null=True, blank=True)
+    updated_by = models.UUIDField(null=True, blank=True)
+
+    class Meta:
+        abstract = True
+
+
+class SoftDeleteManager(models.Manager):
+    """
+    Default manager that hides soft-deleted rows. Use `all_objects`
+    (declared on `SoftDeleteMixin`) when you need to see deleted rows —
+    e.g., for audit reports, compliance exports, or recovery.
+    """
+
+    def get_queryset(self) -> models.QuerySet:
+        return super().get_queryset().filter(deleted_at__isnull=True)
+
+
+class AllObjectsManager(models.Manager):
+    """Manager that returns every row including soft-deleted ones."""
+
+    def get_queryset(self) -> models.QuerySet:
+        return super().get_queryset()
+
+
+class SoftDeleteMixin(models.Model):
+    """
+    Adds soft-delete columns and the filtering manager.
+
+    Semantics:
+      - `delete()` is overridden to set `deleted_at = now()` (soft).
+      - `hard_delete()` performs the normal Django deletion (for GDPR /
+        data-subject-removal flows where a real purge is required).
+      - `objects` is the soft-delete-aware manager: default queries
+        do not see deleted rows.
+      - `all_objects` returns every row including deleted ones.
+      - `restore()` clears the deletion marker.
+
+    The manager filter uses `deleted_at IS NULL`. We do not try to filter
+    via a boolean column — timestamp-based soft-delete gives you retention
+    windows, "deleted last 30 days" reports, and lets the column double
+    as a retention-expiry column.
+    """
+
+    deleted_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    deleted_by = models.UUIDField(null=True, blank=True)
+
+    objects = SoftDeleteManager()
+    all_objects = AllObjectsManager()
+
+    class Meta:
+        abstract = True
+
+    def delete(self, using=None, keep_parents=False, *, deleted_by: uuid.UUID | None = None):
+        """
+        Soft delete: set `deleted_at = now()`. Does NOT cascade.
+        Passing `hard=True` via `hard_delete()` performs a real delete.
+        """
+        from django.utils import timezone
+
+        self.deleted_at = timezone.now()
+        if deleted_by is not None:
+            self.deleted_by = deleted_by
+        self.save(update_fields=['deleted_at', 'deleted_by'])
+
+    def hard_delete(self, using=None, keep_parents=False):
+        """Irreversible, full-row deletion. Use for GDPR right-to-erasure."""
+        return super().delete(using=using, keep_parents=keep_parents)
+
+    def restore(self) -> None:
+        """Clear the soft-delete marker."""
+        self.deleted_at = None
+        self.deleted_by = None
+        self.save(update_fields=['deleted_at', 'deleted_by'])
+
+    @property
+    def is_deleted(self) -> bool:
+        return self.deleted_at is not None

--- a/backend/optiforge/platform/tenancy/models.py
+++ b/backend/optiforge/platform/tenancy/models.py
@@ -1,6 +1,11 @@
 import uuid
 from django.db import models
 
+from optiforge.platform.tenancy.mixins import (
+    AuditMixin,
+    SoftDeleteMixin,
+)
+
 
 class Tenant(models.Model):
     """Core Tenant model with full provisioning lifecycle."""
@@ -66,9 +71,43 @@ class TenantAwareModel(models.Model):
     """
     Abstract base model for all tenant-scoped entities.
     Enforces a non-nullable tenant_id and provides the base for RLS.
+
+    For new tables prefer `AuditedTenantModel` below, which composes
+    audit + soft-delete mixins. `TenantAwareModel` is kept unchanged so
+    existing migrations remain stable; adoption of the richer base is
+    an explicit per-model migration (separate issue).
     """
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     tenant = models.ForeignKey(Tenant, on_delete=models.PROTECT, db_index=True)
 
     class Meta:
+        abstract = True
+
+
+class AuditedTenantModel(TenantAwareModel, AuditMixin, SoftDeleteMixin):
+    """
+    Tenant-scoped model with audit columns and soft-delete semantics.
+
+    This is the recommended base for new core / modes / pack models.
+    It adds:
+      - AuditMixin:       created_at, updated_at, created_by, updated_by
+      - SoftDeleteMixin:  deleted_at, deleted_by + soft-delete manager
+
+    Default querysets hide soft-deleted rows. Use `Model.all_objects`
+    to query across deleted rows (audit reports, compliance exports).
+
+    See `optiforge.platform.tenancy.mixins` for the semantics and
+    ADR-0004 §"Obligations accepted" for the cross-backend contract.
+
+    Usage:
+
+        class MyEntity(AuditedTenantModel):
+            name = models.CharField(max_length=255)
+
+            class Meta:
+                # If you define Meta, inherit abstract from parent explicitly:
+                abstract = False  # or omit — default is False for concrete models
+    """
+
+    class Meta(TenantAwareModel.Meta):
         abstract = True

--- a/backend/optiforge/test_settings.py
+++ b/backend/optiforge/test_settings.py
@@ -13,3 +13,9 @@ DATABASES = {
 
 # JWT secret for testing
 JWT_SECRET = 'test-secret-key'
+
+# Register the test-only app that exercises the audit + soft-delete
+# mixins (see tests/audit_soft_delete/).
+INSTALLED_APPS = INSTALLED_APPS + [  # noqa: F405 (star import above)
+    'tests.audit_soft_delete.apps.AuditSoftDeleteTestConfig',
+]

--- a/backend/tests/audit_soft_delete/apps.py
+++ b/backend/tests/audit_soft_delete/apps.py
@@ -1,0 +1,10 @@
+"""Test-only Django app that exposes a concrete AuditedTenantModel
+subclass so the audit + soft-delete mixins can be exercised end-to-end
+without touching real platform/core tables."""
+from django.apps import AppConfig
+
+
+class AuditSoftDeleteTestConfig(AppConfig):
+    name = 'tests.audit_soft_delete'
+    label = 'audit_soft_delete_test'  # short; avoids collision with platform app labels
+    default_auto_field = 'django.db.models.BigAutoField'

--- a/backend/tests/audit_soft_delete/models.py
+++ b/backend/tests/audit_soft_delete/models.py
@@ -1,0 +1,14 @@
+"""Concrete test model exercising AuditedTenantModel (tenancy + audit
++ soft-delete). Only loaded under optiforge.test_settings."""
+from django.db import models
+
+from optiforge.platform.tenancy.models import AuditedTenantModel
+
+
+class DummyAuditedEntity(AuditedTenantModel):
+    """Minimal concrete entity for the mixin test suite."""
+
+    name = models.CharField(max_length=255)
+
+    class Meta:
+        app_label = 'audit_soft_delete_test'

--- a/backend/tests/audit_soft_delete/test_mixins.py
+++ b/backend/tests/audit_soft_delete/test_mixins.py
@@ -1,0 +1,150 @@
+"""
+End-to-end tests for the AuditMixin + SoftDeleteMixin contract.
+
+These are the canonical contract tests for the semantics described in
+ADR-0004 §"Obligations accepted" and in
+optiforge.platform.tenancy.mixins. The NestJS counterpart at
+b3-erp/backend/test/unit/common/base-entity.spec.ts enforces the same
+semantics on the other backend.
+"""
+from __future__ import annotations
+
+import uuid
+import time
+
+import pytest
+
+from optiforge.platform.tenancy.models import Tenant
+from tests.audit_soft_delete.models import DummyAuditedEntity
+
+
+@pytest.fixture
+def tenant(db):
+    return Tenant.objects.create(name='AuditMixin Test Tenant', status='active')
+
+
+# ---------------------------------------------------------------------------
+# AuditMixin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_created_at_is_set_on_creation(tenant):
+    entity = DummyAuditedEntity.objects.create(tenant=tenant, name='alpha')
+    assert entity.created_at is not None
+
+
+@pytest.mark.django_db
+def test_updated_at_advances_on_save(tenant):
+    entity = DummyAuditedEntity.objects.create(tenant=tenant, name='alpha')
+    first_updated = entity.updated_at
+    time.sleep(0.01)  # ensure clock tick on very fast CI
+    entity.name = 'beta'
+    entity.save()
+    assert entity.updated_at > first_updated
+
+
+@pytest.mark.django_db
+def test_created_by_and_updated_by_are_nullable_uuids(tenant):
+    user_a = uuid.uuid4()
+    entity = DummyAuditedEntity.objects.create(
+        tenant=tenant, name='alpha', created_by=user_a, updated_by=user_a,
+    )
+    assert entity.created_by == user_a
+    assert entity.updated_by == user_a
+
+
+# ---------------------------------------------------------------------------
+# SoftDeleteMixin — default manager
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_default_manager_hides_soft_deleted_rows(tenant):
+    alive = DummyAuditedEntity.objects.create(tenant=tenant, name='alive')
+    dead = DummyAuditedEntity.objects.create(tenant=tenant, name='dead')
+    dead.delete()
+
+    visible = list(DummyAuditedEntity.objects.values_list('id', flat=True))
+    assert alive.id in visible
+    assert dead.id not in visible
+
+
+@pytest.mark.django_db
+def test_all_objects_returns_every_row_including_deleted(tenant):
+    alive = DummyAuditedEntity.objects.create(tenant=tenant, name='alive')
+    dead = DummyAuditedEntity.objects.create(tenant=tenant, name='dead')
+    dead.delete()
+
+    all_ids = set(DummyAuditedEntity.all_objects.values_list('id', flat=True))
+    assert {alive.id, dead.id}.issubset(all_ids)
+
+
+# ---------------------------------------------------------------------------
+# SoftDeleteMixin — delete / restore / hard_delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_delete_is_soft_and_stamps_deleted_at(tenant):
+    entity = DummyAuditedEntity.objects.create(tenant=tenant, name='alpha')
+    assert entity.deleted_at is None
+    entity.delete()
+    entity.refresh_from_db()
+    assert entity.deleted_at is not None
+    assert entity.is_deleted is True
+
+
+@pytest.mark.django_db
+def test_delete_records_deleted_by_when_provided(tenant):
+    user = uuid.uuid4()
+    entity = DummyAuditedEntity.objects.create(tenant=tenant, name='alpha')
+    entity.delete(deleted_by=user)
+    entity.refresh_from_db()
+    assert entity.deleted_by == user
+
+
+@pytest.mark.django_db
+def test_restore_clears_the_soft_delete_marker(tenant):
+    entity = DummyAuditedEntity.objects.create(tenant=tenant, name='alpha')
+    entity.delete()
+    assert entity.is_deleted
+    entity.restore()
+    entity.refresh_from_db()
+    assert entity.deleted_at is None
+    assert entity.deleted_by is None
+    assert entity.is_deleted is False
+
+
+@pytest.mark.django_db
+def test_restored_row_is_visible_to_default_manager_again(tenant):
+    entity = DummyAuditedEntity.objects.create(tenant=tenant, name='alpha')
+    entity.delete()
+    assert not DummyAuditedEntity.objects.filter(id=entity.id).exists()
+    entity.restore()
+    assert DummyAuditedEntity.objects.filter(id=entity.id).exists()
+
+
+@pytest.mark.django_db
+def test_hard_delete_removes_the_row_completely(tenant):
+    entity = DummyAuditedEntity.objects.create(tenant=tenant, name='alpha')
+    entity_id = entity.id
+    entity.hard_delete()
+    assert not DummyAuditedEntity.all_objects.filter(id=entity_id).exists()
+
+
+# ---------------------------------------------------------------------------
+# Tenant scoping still works alongside the mixins (regression check)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_mixins_compose_with_tenant_scoping(tenant):
+    other = Tenant.objects.create(name='Other Tenant', status='active')
+    DummyAuditedEntity.objects.create(tenant=tenant, name='mine')
+    DummyAuditedEntity.objects.create(tenant=other, name='yours')
+
+    mine = list(DummyAuditedEntity.objects.filter(tenant=tenant).values_list('name', flat=True))
+    yours = list(DummyAuditedEntity.objects.filter(tenant=other).values_list('name', flat=True))
+    assert mine == ['mine']
+    assert yours == ['yours']


### PR DESCRIPTION
## Summary

ADR-0004 §"Obligations accepted" pins audit columns + soft-delete semantics as a cross-cutting contract that must stay identical across Django and NestJS. This PR introduces the base classes on **both** sides, with 22 contract tests.

### Columns (same semantics on both backends)

| Column | Django (snake) | NestJS (camel) | Purpose |
|---|---|---|---|
| UUID PK | `id` | `id` | Primary key |
| Insert time | `created_at` | `createdAt` | `auto_now_add` / `@CreateDateColumn` |
| Last save | `updated_at` | `updatedAt` | `auto_now` / `@UpdateDateColumn` |
| Creator | `created_by` | `createdBy` | Nullable UUID (JWT sub) |
| Last mutator | `updated_by` | `updatedBy` | Nullable UUID |
| Soft-delete marker | `deleted_at` | `deletedAt` | Nullable timestamp; `@DeleteDateColumn` on NestJS |
| Deletion attribution | `deleted_by` | `deletedBy` | Nullable UUID |

### Behavior

- Default finds **exclude** soft-deleted rows.
- Explicit access to deleted rows via `Model.all_objects` (Django) or `{ withDeleted: true }` (TypeORM).
- `delete()` is soft. `hard_delete()` / `remove()` is the full purge for GDPR right-to-erasure.
- `restore()` clears the marker.
- `deleted_by` is stamped via `entity.delete(deleted_by=uuid)` (Django) or `entity.markDeletedBy(uuid); repo.softRemove(entity)` (NestJS).

## Changes

**Django (`/backend/`):**
- New [`optiforge/platform/tenancy/mixins.py`](../blob/feature/backend-improvement-113-soft-delete-audit/backend/optiforge/platform/tenancy/mixins.py) — `AuditMixin`, `SoftDeleteMixin`, `SoftDeleteManager`, `AllObjectsManager`.
- Updated [`optiforge/platform/tenancy/models.py`](../blob/feature/backend-improvement-113-soft-delete-audit/backend/optiforge/platform/tenancy/models.py) — new `AuditedTenantModel` composes all three (recommended base for new tenant-scoped tables). `TenantAwareModel` is **unchanged** so existing migrations remain stable.
- Test-only app at [`tests/audit_soft_delete/`](../blob/feature/backend-improvement-113-soft-delete-audit/backend/tests/audit_soft_delete/) registered in `optiforge.test_settings`, providing a concrete `DummyAuditedEntity`.
- 11 pytest cases covering insert/save audit, nullable attribution, manager filtering, `all_objects` bypass, soft delete, restore, hard delete, tenancy composition.

**NestJS (`/b3-erp/backend/`):**
- New [`src/common/entities/base.entity.ts`](../blob/feature/backend-improvement-113-soft-delete-audit/b3-erp/backend/src/common/entities/base.entity.ts) — `AuditedEntity`, `TenantAuditedEntity`.
- 11 Jest cases covering decorator metadata, type/nullability of each column, `isDeleted`/`markDeletedBy` helpers, metadata inheritance.

## Verification

- **Django**: `pytest tests/` — 47 pass (36 pre-existing + 11 new).
- **NestJS**: `jest test/unit/common/base-entity.spec.ts` — 11/11 pass.
- **Full NestJS suite**: 87/92 pass; the 5 failures are pre-existing in `test/unit/approval-workflow.service.spec.ts` (missing `NotificationService` mock) — unrelated to this change, which only adds new files.

## Scope boundary

This PR introduces the base classes + contract tests. It does **not** migrate existing models/entities onto the new bases — that is deliberately a separate, per-model review so the manager-filter behaviour change can be vetted per call site before switching. Tracked as a follow-up.

## Dependency

References the cross-backend contract table in [#119](https://github.com/boscosabujohn/ManufacturingOS/pull/119)'s `docs/architecture-dual-backend.md`. Ideally merge #119 first.

## Test plan

- [ ] New Django models opt in: `class MyEntity(AuditedTenantModel)` — audit + soft-delete columns appear in the migration.
- [ ] New NestJS entities opt in: `class MyEntity extends TenantAuditedEntity` — `@DeleteDateColumn` filters default finds.
- [ ] Soft delete → row hidden from list endpoints; `all_objects` / `withDeleted` still returns it.
- [ ] `hard_delete()` purges.
- [ ] `restore()` brings back.
- [ ] `deleted_by` stamping works via both `delete(deleted_by=x)` (Django) and `markDeletedBy(x); softRemove()` (NestJS).

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)