### PR TITLE
chore(gitignore): cover nested coverage/ and Claude harness runtime lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 
 # Testing
 /coverage
+**/coverage/
 
 # Production
 /build
@@ -47,6 +48,10 @@ next-env.d.ts
 *.swp
 *.swo
 *~
+
+# Claude Code harness runtime artifacts
+.claude/scheduled_tasks.lock
+.claude/projects/
 
 # Logs
 logs/


### PR DESCRIPTION
## Summary

A few `.gitignore` patterns weren't catching their targets — files that show up untracked after a normal dev session:

- `/coverage` only ignored top-level `coverage/`, leaving `b3-erp/backend/coverage/` and `b3-erp/frontend/coverage/` untracked after `jest --coverage`. Add `**/coverage/` to catch nested ones.
- `.claude/scheduled_tasks.lock` is a per-session runtime artifact from the Claude Code harness. `.claude/projects/` holds session transcripts. Neither belongs in the repo.

After this lands, a working tree freshly run through tests + Claude is clean.

## Test plan

- [ ] `git status` after a `jest --coverage` run in either b3-erp tree shows nothing.
- [ ] `git status` after a Claude Code session shows nothing under `.claude/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)